### PR TITLE
Potential fix for code scanning alert no. 77: Server-side request forgery

### DIFF
--- a/routes/profileImageUrlUpload.ts
+++ b/routes/profileImageUrlUpload.ts
@@ -7,6 +7,8 @@ import fs from 'node:fs'
 import { Readable } from 'node:stream'
 import { finished } from 'node:stream/promises'
 import { type Request, type Response, type NextFunction } from 'express'
+import dns from 'node:dns/promises'
+import net from 'node:net'
 
 import * as security from '../lib/insecurity'
 import { UserModel } from '../models/user'
@@ -27,23 +29,51 @@ export function profileImageUrlUpload () {
         'cdn.pixabay.com'
         // Add other legitimate image hosts as needed
       ]
-      function isSafeImageUrl(imageUrl) {
+      async function isSafeImageUrl(imageUrl: string): Promise<boolean> {
+        function isPrivateIp(ip: string): boolean {
+          if (net.isIPv4(ip)) {
+            return (
+              ip.startsWith('10.') ||
+              ip.startsWith('127.') ||
+              ip.startsWith('169.254.') ||
+              ip.startsWith('192.168.') ||
+              /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(ip)
+            )
+          }
+          if (net.isIPv6(ip)) {
+            // Link-local, unique-local, loopback, etc
+            return (
+              ip === '::1' ||
+              ip.startsWith('fe80:') ||
+              ip.startsWith('fc00:') ||
+              ip.startsWith('fd00:')
+            )
+          }
+          return false
+        }
         try {
           const parsedUrl = new URL(imageUrl)
           // Enforce http(s) protocol
           if (!['http:', 'https:'].includes(parsedUrl.protocol)) return false
-          // Host domain should be in the allow-list and not a localhost or private IP
           const hostname = parsedUrl.hostname
-          // Check for localhost and local IPs
+          // Fast check for localhost, but don't rely on just string
           if (
             hostname === 'localhost' ||
             hostname === '127.0.0.1' ||
-            hostname === '::1' ||
-            /^10\./.test(hostname) ||
-            /^192\.168\./.test(hostname) ||
-            /^172\.(1[6-9]|2[0-9]|3[0-1])\./.test(hostname) ||
-            /^169\.254\./.test(hostname)
+            hostname === '::1'
           ) return false
+          // Check DNS resolution for IP addresses (can be CNAME to internal IP)
+          let addresses: string[] = []
+          try {
+            // Supports both IPv4 and IPv6
+            const result4 = await dns.resolve4(hostname).catch(() => [])
+            const result6 = await dns.resolve6(hostname).catch(() => [])
+            addresses = [...result4, ...result6]
+          } catch (err) {
+            return false // failed to resolve, treat as unsafe
+          }
+          if (addresses.length === 0) return false // No resolved addresses
+          if (addresses.some(ip => isPrivateIp(ip))) return false
           // Check if the host is in the allow-list (allow subdomains)
           if (ALLOWED_IMAGE_HOSTS.some(domain => hostname === domain || hostname.endsWith(`.${domain}`))) {
             return true
@@ -55,7 +85,7 @@ export function profileImageUrlUpload () {
       }
       if (loggedInUser) {
         try {
-          if (!isSafeImageUrl(url)) {
+          if (!(await isSafeImageUrl(url))) {
             res.status(400).send({ error: 'Invalid image URL. Only trusted image hosts are allowed.' })
             return
           }


### PR DESCRIPTION
Potential fix for [https://github.com/sidneisperandio7/juice-shop/security/code-scanning/77](https://github.com/sidneisperandio7/juice-shop/security/code-scanning/77)

The best way to fix this SSRF issue is to supplement the existing user input validation with robust hostname/IP address resolution and comparison, using a maintained third-party package to enforce that the resolved destination matches an allowed public IP/netblock. In practice, you'll supplement the `isSafeImageUrl` function so that after parsing and basic protocol checks, you perform a DNS lookup of the hostname (including potential CNAME chains), resolve all associated IP addresses, and ensure none fall within private/reserved address ranges. Using a package such as `ssrf-detector`, `net`, or `ip`, you can reliably block requests to private/internal destinations, mitigating typical SSRF edge cases (DNS rebinding, IPv6, etc).

**Required changes:**

- Import a robust SSRF protection utility, such as `is-ip`, `ip6`, or a purpose-built SSRF protection package like `ssrf-safe`.
- Update the `isSafeImageUrl` function (lines 30–55) to actually resolve the hostname and disallow requests to private/reserved IPs programmatically (not just via regex).
- This may require `isSafeImageUrl` to be made `async`, and the call to be `await`ed.
- Ensure the rest of the function (especially calls to `isSafeImageUrl`, error handling, etc.) works asynchronously.

All changes will only be within your shown code snippet in `routes/profileImageUrlUpload.ts`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
