### PR TITLE
Potential fix for code scanning alert no. 73: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ export function trackOrder () {
     const id = !utils.isChallengeEnabled(challenges.reflectedXssChallenge) ? String(req.params.id).replace(/[^\w-]+/g, '') : utils.trunc(req.params.id, 60)
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.ordersCollection.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.ordersCollection.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/sidneisperandio7/juice-shop/security/code-scanning/73](https://github.com/sidneisperandio7/juice-shop/security/code-scanning/73)

The best way to fix this code injection vulnerability is to avoid using user input in strings that will be evaluated as code (in this case, JavaScript for the MongoDB `$where` operator). Instead, use regular MongoDB queries with parameterization wherever possible.  
- Specifically, replace the `$where` query with an ordinary field-based query like `{ orderId: id }`.
- This change will remove the risk of arbitrary code execution in the database and ensure user input is handled safely, while retaining existing functionality of querying orders by `orderId`.
- Make this replacement inside the routes/trackOrder.ts file, replacing line 18's use of `$where` with a regular query.
- No external imports or helper methods are required, just the updated query.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
